### PR TITLE
Update to v1.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=4.0
+    - setuptools >=40
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [py2k or py<=36]
+  skip: true  # [py<=36]
 
 requirements:
   build:
@@ -22,6 +22,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools >=4.0
+    - wheel
   run:
     - python
     - multidict >=4.0
@@ -38,12 +40,12 @@ test:
 
 about:
   home: https://github.com/aio-libs/yarl
-  license: Apache 2.0
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   license_url: https://www.apache.org/licenses/LICENSE-2.0
   summary: Yet another URL library
-  doc_url: http://yarl.readthedocs.io
+  doc_url: https://yarl.readthedocs.io
   dev_url: https://github.com/aio-libs/yarl
   doc_source_url: https://github.com/aio-libs/yarl/tree/master/docs
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "yarl" %}
-{% set version = "1.6.3" %}
-{% set sha256 = "8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10" %}
+{% set version = "1.8.1" %}
+{% set sha256 = "af887845b8c2e060eb5605ff72b6f2dd2aab7a761379373fd89d314f4752abbf" %}
 
 package:
   name: {{ name|lower }}
@@ -12,9 +12,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [py2k]
+  skip: true  # [py2k or py<=36]
 
 requirements:
   build:
@@ -26,6 +26,7 @@ requirements:
     - python
     - multidict >=4.0
     - idna >=2.0
+    - typing-extensions >= 3.7.4 # [py<38]
 
 test:
   source_files:
@@ -42,6 +43,7 @@ about:
   license: Apache 2.0
   license_family: Apache
   license_file: LICENSE
+  license_url: https://www.apache.org/licenses/LICENSE-2.0
   summary: Yet another URL library
   doc_url: http://yarl.readthedocs.io
   dev_url: https://github.com/aio-libs/yarl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - multidict >=4.0
     - idna >=2.0
-    - typing-extensions >= 3.7.4 # [py<38]
+    - typing-extensions >=3.7.4 # [py<38]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,7 @@ test:
   requires:
     - pytest
   commands:
-    # `test_semicolon_as_separator` broken by changes to `parse_qsl` in recent
-    # Python releases; see <https://github.com/aio-libs/yarl/issues/563>
-    - py.test tests -k 'not test_semicolon_as_separator'
+    - py.test tests
 
 about:
   home: https://github.com/aio-libs/yarl


### PR DESCRIPTION
# Package Info

doc_url: http://yarl.readthedocs.io
dev_url: https://github.com/aio-libs/yarl
doc_source_url: https://github.com/aio-libs/yarl/tree/master/docs

# Info

* Upstream dropped support for python 3.6 and below
* Upstream requires python-extensions for python 3.7
* Also added license_url

# Testing

Dependent packages `vcrpy-2.1.1` and `aiohttp-3.8.1` still pass tests on `osx-arm64` with python 3.10