### PR TITLE
Updated to 1.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "yarl" %}
-{% set version = "1.9.3" %}
-{% set sha256 = "4a14907b597ec55740f63e52d7fee0e9ee09d5b9d57a4f399a7423268e457b57" %}
+{% set version = "1.11.0" %}
+{% set sha256 = "f86f4f4a57a29ef08fa70c4667d04c5e3ba513500da95586208b285437cb9592" %}
 
 package:
   name: {{ name|lower }}
@@ -21,7 +21,7 @@ requirements:
   host:
     - python
     - expandvars
-    - setuptools >=47
+    - setuptools
     - wheel
     - tomli  # [py<311]
     - pip
@@ -36,13 +36,16 @@ test:
   imports:
     - yarl
   source_files:
+    - pytest.ini
     - tests
   requires:
     - pip
     - pytest
+    - pytest-cov
+    - pytest-xdist
   commands:
     - pip check
-    - py.test tests
+    - pytest -v tests
 
 about:
   home: https://github.com/aio-libs/yarl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,18 +30,15 @@ requirements:
     - python
     - multidict >=4.0
     - idna >=2.0
-    - typing-extensions >=3.7.4 # [py<38]
 
 test:
   imports:
     - yarl
   source_files:
-    - pytest.ini
     - tests
   requires:
     - pip
     - pytest
-    - pytest-cov
     - pytest-xdist
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: Yet another URL library
+  description: The module provides handy URL class for URL parsing and changing.
   doc_url: https://yarl.aio-libs.org
   dev_url: https://github.com/aio-libs/yarl
 


### PR DESCRIPTION
yarl 1.11.0

**Destination channel:** defaults

### Links

- [PKG-5642](https://anaconda.atlassian.net/browse/PKG-5642)
- [Upstream repository](https://github.com/aio-libs/yarl/blob/v1.11.0)
- [Upstream changelog/diff](https://github.com/aio-libs/yarl/blob/v1.11.0/CHANGES.rst)

### Explanation of changes:

- Updated version for Spyder 6.0.1 support
- Run unit tests with standard pytest command


[PKG-5642]: https://anaconda.atlassian.net/browse/PKG-5642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ